### PR TITLE
Fix Material components in tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,12 +2,16 @@ import { TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { NavBarComponent } from './shared/nav-bar/nav-bar.component';
+import { MaterialModule } from './material/material.module';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule,
+        MaterialModule,
+        BrowserAnimationsModule
       ],
       declarations: [
         AppComponent,

--- a/src/app/shared/nav-bar/nav-bar.component.html
+++ b/src/app/shared/nav-bar/nav-bar.component.html
@@ -1,5 +1,5 @@
 <p>
-  <mat-toolbar color="">
+  <mat-toolbar>
     <mat-toolbar-row class="center-items" style="background-color: #E5DFDE;">
       <span class="center-text">{{ title() }}</span>
       <span class="example-spacer"></span>

--- a/src/app/shared/nav-bar/nav-bar.component.spec.ts
+++ b/src/app/shared/nav-bar/nav-bar.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { MaterialModule } from '../../material/material.module';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NavBarComponent } from './nav-bar.component';
 
 describe('NavBarComponent', () => {
@@ -8,6 +9,7 @@ describe('NavBarComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [MaterialModule, BrowserAnimationsModule],
       declarations: [ NavBarComponent ]
     })
     .compileComponents();


### PR DESCRIPTION
## Summary
- fix invalid `color` attribute in nav bar template
- import `MaterialModule` in component tests

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f51670bc8330911ceadbce597558